### PR TITLE
Await JSON file writes before exiting the process.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toobig",
   "description": "Check that your files don't get too big.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export default async function tooBig(options: Options = {}): Promise<void> {
 
   const logger = createLogger(options);
   results.forEach(result => logger.log(result));
-  logger.finalize();
+  await logger.finalize();
 
   const anyOverMaxSize = results.some(isOverMaxSize);
   if (anyOverMaxSize) {


### PR DESCRIPTION
Previously if failures are encountered and you specified that you want to
write the JSON results to a file it ends up writing a 0 byte file
because we never `await` the file writing. This change fixes it so it
properly awaits the file writes.